### PR TITLE
Only log ArgumentErrors

### DIFF
--- a/lib/traject/horizon_reader.rb
+++ b/lib/traject/horizon_reader.rb
@@ -301,7 +301,13 @@ module Traject
       # _except_ for four legal ones (including MARC delimiters). 
       # http://www.loc.gov/marc/specifications/specchargeneral.html#controlfunction
       # this is all bytes from 0x00 to 0x19 except for the allowed 1B, 1D, 1E, 1F. 
-      text.gsub!(/[\x00-\x1A\x1C]/, '')
+      begin
+        text.gsub!(/[\x00-\x1A\/1F]/, '')
+      rescue StandardError => e
+        logger.info "HorizonReader, illegal chars found #{e}"
+        logger.info text
+        text.scrub!
+      end
 
       return text
     end

--- a/traject_horizon.gemspec
+++ b/traject_horizon.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "marc-marc4j" # for marc4j jar files
   spec.add_dependency "ensure_valid_encoding", ">= 0.5.3"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
 end


### PR DESCRIPTION
This changes the HorizonReader class so that those
errors will not result in indexing stopping.

We have encountered a large number of UTF-8 errors
with recent MARC loads into Horizon. This will
ensure that the bib number is logged so that they can
be corrected, but won't stop indexing completely.

Other Exceptions will cause indexing to stop.