### PR TITLE
Only log ArgumentErrors

### DIFF
--- a/lib/traject/horizon_reader.rb
+++ b/lib/traject/horizon_reader.rb
@@ -302,7 +302,7 @@ module Traject
       # http://www.loc.gov/marc/specifications/specchargeneral.html#controlfunction
       # this is all bytes from 0x00 to 0x19 except for the allowed 1B, 1D, 1E, 1F. 
       begin
-        text.gsub!(/[\x00-\x1A\/1F]/, '')
+        text.gsub!(/[\x00-\x1A\x1C]/, '')
       rescue StandardError => e
         logger.info "HorizonReader, illegal chars found #{e}"
         logger.info text


### PR DESCRIPTION
This changes the HorizonReader class so that those
errors will not result in indexing stopping.

We have encountered a large number of UTF-8 errors
with recent MARC loads into Horizon. This will
ensure that the bib number is logged so that they can
be corrected, but won't stop indexing completely.

Other Exceptions will cause indexing to stop.